### PR TITLE
dateTime was ignoring specified local_or_utc value

### DIFF
--- a/src/ezTime.cpp
+++ b/src/ezTime.cpp
@@ -1207,7 +1207,7 @@ String Timezone::dateTime(time_t t, const ezLocalOrUTC_t local_or_utc, const Str
 	String tzname;
 	bool is_dst;
 	int16_t offset;
-	t = tzTime(t, LOCAL_TIME, tzname, is_dst, offset);
+	t = tzTime(t, local_or_utc, tzname, is_dst, offset);
 
 	String tmpstr;
 	uint8_t tmpint8;


### PR DESCRIPTION
Line 1210: always assumed the provided time_t was in local time.

thus the following output:

Timezone localTz;
localTz.setLocation("Australia/Melbourne");

// -- works for TIME_NOW as it gets hydrated in local time Serial.println("Current Time: ");
Serial.print("         UTC: "); Serial.println(UTC.dateTime());
Serial.print("       Local: "); Serial.println(localTz.dateTime());
Serial.println();

// Current Time:
//          UTC: Saturday, 03-Aug-2019 03:56:27 UTC
//        Local: Saturday, 03-Aug-2019 13:56:27 AEST

time_t testTime = 1564953937;
Serial.println("    Simulate: ");
Serial.print("       Local: "); Serial.println(localTz.dateTime(testDate));
Serial.print("       Local: "); Serial.println(localTz.dateTime(testDate, LOCAL_TIME));
Serial.print("       Local: "); Serial.println(localTz.dateTime(testDate, UTC_TIME));

// Simulate:
//       UTC: Sunday, 04-Aug-2019 21:25:37 UTC
//     Local: Sunday, 04-Aug-2019 11:25:37 AEST
//     Local: Sunday, 04-Aug-2019 11:25:37 AEST
//     Local: Sunday, 04-Aug-2019 11:25:37 AEST <--- wrong

with this PR:
// Current Time:
//          UTC: Saturday, 03-Aug-2019 03:56:27 UTC
//        Local: Saturday, 03-Aug-2019 13:56:27 AEST
//
// Simulate:
//       UTC: Sunday, 04-Aug-2019 21:25:37 UTC
//     Local: Sunday, 04-Aug-2019 11:25:37 AEST
//     Local: Sunday, 04-Aug-2019 11:25:37 AEST
//     Local: Monday, 05-Aug-2019 07:25:37 AEST <--- correct