### PR TITLE
Enable support for ezTime as ESP-IDF component.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.5)
+
+idf_component_register(
+                       INCLUDE_DIRS "src"
+                       SRC_DIRS "src"
+                       REQUIRES arduino
+                       )
+project(ezTime)


### PR DESCRIPTION
This enables support for ezTime as an ESP-IDF component (with Arduino as a component).

This is a common pattern and is also done by the hugely popular adafruit / Adafruit-GFX-Library library.